### PR TITLE
Add dark mode toggle with persistent theme selection

### DIFF
--- a/about.html
+++ b/about.html
@@ -11,6 +11,7 @@
         <nav>
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
+            <button id="theme-toggle" aria-label="Toggle dark mode">Dark Mode</button>
         </nav>
         <h1>About Me</h1>
     </header>
@@ -25,5 +26,6 @@
             <li>Uploading files to GitHub</li>
         </ul>
     </section>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -11,11 +11,13 @@
         <nav>
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
+            <button id="theme-toggle" aria-label="Toggle dark mode">Dark Mode</button>
         </nav>
     </header>
     <section>
         <h1>Welcome to My Test Page</h1>
         <p>This is just a test page to get started with GitHub!</p>
     </section>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggleButton = document.getElementById('theme-toggle');
+  const savedTheme = localStorage.getItem('theme');
+
+  if (savedTheme === 'dark') {
+    document.body.classList.add('dark-mode');
+    if (toggleButton) {
+      toggleButton.textContent = 'Light Mode';
+    }
+  }
+
+  toggleButton.addEventListener('click', () => {
+    document.body.classList.toggle('dark-mode');
+    const isDark = document.body.classList.contains('dark-mode');
+    toggleButton.textContent = isDark ? 'Light Mode' : 'Dark Mode';
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -3,6 +3,7 @@ body {
     margin: 0;
     padding: 0;
     background-color: #f4f4f4;
+    color: #000;
 }
 header {
     background-color: #333;
@@ -18,6 +19,17 @@ nav a {
 nav a:hover {
     text-decoration: underline;
 }
+nav button {
+    background: none;
+    border: none;
+    color: #fff;
+    cursor: pointer;
+    margin-left: 10px;
+    font: inherit;
+}
+nav button:hover {
+    text-decoration: underline;
+}
 section {
     padding: 2em;
     max-width: 600px;
@@ -25,4 +37,21 @@ section {
     background-color: #fff;
     border-radius: 8px;
     box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+/* Dark mode styles */
+body.dark-mode {
+    background-color: #121212;
+    color: #e0e0e0;
+}
+body.dark-mode header {
+    background-color: #1e1e1e;
+}
+body.dark-mode section {
+    background-color: #1e1e1e;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.5);
+}
+body.dark-mode nav a,
+body.dark-mode nav button {
+    color: #fff;
 }


### PR DESCRIPTION
## Summary
- add dark mode toggle button to navigation on all pages
- persist theme choice in localStorage and apply styling for dark mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b33625f9e0832290bd5c94963d90c6