### PR TITLE
Add contact form with validation and success message

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -4,40 +4,34 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Contact Me</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            margin: 0;
-            padding: 0;
-            background-color: #f4f4f4;
-        }
-        header {
-            background-color: #333;
-            color: #fff;
-            padding: 1em;
-            text-align: center;
-        }
-        section {
-            padding: 2em;
-            max-width: 600px;
-            margin: 20px auto;
-            background-color: #fff;
-            border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-        }
-        h1, p {
-            margin: 0 0 1em;
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <header>
+        <nav>
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="contact.html">Contact</a>
+            <button id="theme-toggle" aria-label="Toggle dark mode">Dark Mode</button>
+        </nav>
         <h1>Contact Me</h1>
     </header>
     <section>
-        <h2>Get in Touch</h2>
-        <p>You can reach me by sending an email to <a href="mailto:example@example.com">example@example.com</a>.</p>
+        <form id="contact-form">
+            <label for="name">Name</label>
+            <input type="text" id="name" name="name" required>
+
+            <label for="email">Email</label>
+            <input type="email" id="email" name="email" required>
+
+            <label for="message">Message</label>
+            <textarea id="message" name="message" rows="5" required></textarea>
+
+            <button type="submit">Send</button>
+        </form>
+        <p id="form-success">Thank you for your message!</p>
     </section>
+    <script src="script.js"></script>
 </body>
 </html>
 

--- a/script.js
+++ b/script.js
@@ -15,4 +15,31 @@ document.addEventListener('DOMContentLoaded', () => {
     toggleButton.textContent = isDark ? 'Light Mode' : 'Dark Mode';
     localStorage.setItem('theme', isDark ? 'dark' : 'light');
   });
+
+  const contactForm = document.getElementById('contact-form');
+  if (contactForm) {
+    const successMessage = document.getElementById('form-success');
+    contactForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const name = document.getElementById('name').value.trim();
+      const email = document.getElementById('email').value.trim();
+      const message = document.getElementById('message').value.trim();
+
+      if (!name || !email || !message) {
+        alert('Please fill in all fields.');
+        return;
+      }
+
+      const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      if (!emailPattern.test(email)) {
+        alert('Please enter a valid email address.');
+        return;
+      }
+
+      contactForm.reset();
+      if (successMessage) {
+        successMessage.style.display = 'block';
+      }
+    });
+  }
 });

--- a/styles.css
+++ b/styles.css
@@ -39,6 +39,42 @@ section {
     box-shadow: 0 4px 8px rgba(0,0,0,0.1);
 }
 
+form {
+    display: flex;
+    flex-direction: column;
+}
+
+form label {
+    margin-top: 1em;
+}
+
+form input,
+form textarea {
+    padding: 0.5em;
+    margin-top: 0.5em;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+form button {
+    margin-top: 1em;
+    padding: 0.5em 1em;
+    border: none;
+    background-color: #333;
+    color: #fff;
+    cursor: pointer;
+}
+
+form button:hover {
+    background-color: #555;
+}
+
+#form-success {
+    color: green;
+    margin-top: 1em;
+    display: none;
+}
+
 /* Dark mode styles */
 body.dark-mode {
     background-color: #121212;
@@ -54,4 +90,22 @@ body.dark-mode section {
 body.dark-mode nav a,
 body.dark-mode nav button {
     color: #fff;
+}
+body.dark-mode input,
+body.dark-mode textarea {
+    background-color: #1e1e1e;
+    color: #e0e0e0;
+    border-color: #555;
+}
+
+body.dark-mode form button {
+    background-color: #333;
+}
+
+body.dark-mode form button:hover {
+    background-color: #444;
+}
+
+body.dark-mode #form-success {
+    color: #4caf50;
 }


### PR DESCRIPTION
## Summary
- Replace static contact page with a form for name, email, and message
- Add client-side validation and success feedback in shared script
- Extend site styles for form elements and dark mode support

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b36ceff28883229e45e781e5cd8521