### PR TITLE
Add Mermaid diagram editor page and navigation links

### DIFF
--- a/about.html
+++ b/about.html
@@ -11,6 +11,7 @@
         <nav>
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
+            <a href="mermaid.html">Mermaid</a>
             <button id="theme-toggle" aria-label="Toggle dark mode">Dark Mode</button>
         </nav>
         <h1>About Me</h1>

--- a/contact.html
+++ b/contact.html
@@ -12,6 +12,7 @@
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
             <a href="contact.html">Contact</a>
+            <a href="mermaid.html">Mermaid</a>
             <button id="theme-toggle" aria-label="Toggle dark mode">Dark Mode</button>
         </nav>
         <h1>Contact Me</h1>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
         <a href="index.html">Home</a>
         <a href="about.html">About</a>
         <a href="contact.html">Contact</a>
+        <a href="mermaid.html">Mermaid</a>
     </nav>
     <h1>Welcome 🤗 to My Test Page</h1>
     <p>This is just a test page to get started with🍀🦷😜🐱 GitHub!</p>
@@ -20,6 +21,7 @@
         <nav>
             <a href="index.html">Home</a>
             <a href="about.html">About</a>
+            <a href="mermaid.html">Mermaid</a>
             <button id="theme-toggle" aria-label="Toggle dark mode">Dark Mode</button>
         </nav>
     </header>

--- a/mermaid-app.js
+++ b/mermaid-app.js
@@ -1,0 +1,109 @@
+const DEFAULT_CODE = `flowchart TD
+    A([Start]) --> B{Multiple beds down?}
+    B -- No --> C[Single bed only → Troubleshoot motor/control card]
+    B -- Yes --> D([Perform bypass relay test\n(midpoint bed)])
+    D --> E{Upstream beds run?}
+    E -- Yes --> F[Fault is downstream → Continue bed-to-bed]
+    E -- No --> G[Fault is at or before this bed]
+    F --> H{All tests pass but beds still down?}
+    G --> H
+    H -- Yes --> I[[Suspect CR-BP relay anomaly]]
+    H -- No --> J[Swap with known-good relay]
+    I --> J
+    J --> K{System restored?}
+    K -- Yes --> L([Replace faulty relay])
+    K -- No --> Z((End))
+    L --> Z
+
+    style B fill:#42a5f5,stroke:#000,stroke-width:2px
+    style E fill:#42a5f5,stroke:#000,stroke-width:2px
+    style H fill:#42a5f5,stroke:#000,stroke-width:2px
+    style K fill:#42a5f5,stroke:#000,stroke-width:2px
+    style I fill:#ffeb3b,stroke:#000,stroke-width:2px
+    style Z fill:#00c853,stroke:#000,stroke-width:2px`;
+
+document.addEventListener('DOMContentLoaded', () => {
+  const textarea = document.getElementById('mermaid-code');
+  const renderBtn = document.getElementById('render-btn');
+  const copyBtn = document.getElementById('copy-btn');
+  const clearBtn = document.getElementById('clear-btn');
+  const svgBtn = document.getElementById('svg-btn');
+  const pngBtn = document.getElementById('png-btn');
+  const preview = document.getElementById('mermaid-preview');
+  const errorMsg = document.getElementById('error-msg');
+  const themeSelect = document.getElementById('theme-select');
+
+  textarea.value = DEFAULT_CODE;
+  mermaid.initialize({ startOnLoad: false, securityLevel: 'strict', theme: themeSelect.value });
+
+  async function renderDiagram() {
+    errorMsg.textContent = '';
+    try {
+      const { svg } = await mermaid.render('mmd-' + Math.random().toString(36).slice(2), textarea.value);
+      preview.innerHTML = svg;
+    } catch (err) {
+      errorMsg.textContent = err.message || String(err);
+      preview.innerHTML = '';
+    }
+  }
+
+  renderBtn.addEventListener('click', renderDiagram);
+
+  copyBtn.addEventListener('click', () => {
+    navigator.clipboard.writeText(textarea.value);
+  });
+
+  clearBtn.addEventListener('click', () => {
+    textarea.value = '';
+    preview.innerHTML = '';
+    errorMsg.textContent = '';
+  });
+
+  svgBtn.addEventListener('click', () => {
+    const svgEl = preview.querySelector('svg');
+    if (!svgEl) return;
+    const serializer = new XMLSerializer();
+    const svgString = serializer.serializeToString(svgEl);
+    const blob = new Blob([svgString], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'diagram.svg';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+
+  pngBtn.addEventListener('click', () => {
+    const svgEl = preview.querySelector('svg');
+    if (!svgEl) return;
+    const serializer = new XMLSerializer();
+    const svgString = serializer.serializeToString(svgEl);
+    const img = new Image();
+    const url = 'data:image/svg+xml;base64,' + btoa(unescape(encodeURIComponent(svgString)));
+    img.onload = function () {
+      const canvas = document.createElement('canvas');
+      canvas.width = img.width;
+      canvas.height = img.height;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+      ctx.drawImage(img, 0, 0);
+      canvas.toBlob((blob) => {
+        if (!blob) return;
+        const blobUrl = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = blobUrl;
+        a.download = 'diagram.png';
+        a.click();
+        URL.revokeObjectURL(blobUrl);
+      }, 'image/png');
+    };
+    img.src = url;
+  });
+
+  themeSelect.addEventListener('change', () => {
+    mermaid.initialize({ startOnLoad: false, securityLevel: 'strict', theme: themeSelect.value });
+    if (preview.querySelector('svg')) {
+      renderDiagram();
+    }
+  });
+});

--- a/mermaid.html
+++ b/mermaid.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mermaid Runner</title>
+    <link rel="stylesheet" href="styles.css">
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+</head>
+<body>
+    <header>
+        <nav>
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="contact.html">Contact</a>
+            <a href="mermaid.html">Mermaid</a>
+            <button id="theme-toggle" aria-label="Toggle dark mode">Dark Mode</button>
+        </nav>
+        <h1>Mermaid Runner</h1>
+    </header>
+    <section>
+        <h2>Run Mermaid Code</h2>
+        <label for="mermaid-code">Mermaid Code:</label>
+        <textarea id="mermaid-code" rows="12" style="width:100%;"></textarea>
+        <div style="margin-top:1em;">
+            <label for="theme-select">Theme:</label>
+            <select id="theme-select">
+                <option value="default">Default</option>
+                <option value="neutral">Neutral</option>
+                <option value="forest">Forest</option>
+                <option value="dark">Dark</option>
+            </select>
+        </div>
+        <div style="margin-top:1em;">
+            <button id="render-btn">Render</button>
+            <button id="copy-btn">Copy</button>
+            <button id="clear-btn">Clear</button>
+            <button id="svg-btn">SVG</button>
+            <button id="png-btn">PNG</button>
+            <span id="error-msg" style="color:red;margin-left:1em;"></span>
+        </div>
+        <div id="mermaid-preview" style="margin-top:1em; overflow:auto;"></div>
+    </section>
+    <script src="script.js"></script>
+    <script src="mermaid-app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone Mermaid Runner page with live editing and export features
- link the diagram tool from home, about, and contact pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8dfb50e488322a1fc605284401d86